### PR TITLE
iqkms-signing: `SigningService` based on Tower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "iqkms-signing",
  "iqkms-types",
  "tonic",
+ "tower",
  "tracing",
 ]
 
@@ -1037,6 +1038,7 @@ name = "iqkms-types"
 version = "0.0.1"
 dependencies = [
  "base16ct",
+ "bytes",
  "ethereum-types",
  "iq-crypto",
 ]
@@ -1050,6 +1052,7 @@ dependencies = [
  "iqkms-signing",
  "tokio",
  "tonic",
+ "tower",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ version = "0.0.1"
 dependencies = [
  "iq-crypto",
  "iqkms-types",
+ "tower",
 ]
 
 [[package]]

--- a/iqkms-ethereum/Cargo.toml
+++ b/iqkms-ethereum/Cargo.toml
@@ -19,6 +19,7 @@ types = { package = "iqkms-types", version = "0.0.1", path = "../iqkms-types", f
 
 # 3rd party dependencies
 tonic = "0.8"
+tower = "0.4"
 tracing = "0.1.37"
 
 [package.metadata.docs.rs]

--- a/iqkms-ethereum/src/signer.rs
+++ b/iqkms-ethereum/src/signer.rs
@@ -2,54 +2,54 @@
 
 use crate::Error;
 use proto::ethereum::{signer_server::Signer, SignDigestRequest, SignEip155Request, Signature};
-use signing::{signature::ecdsa::secp256k1, Keyring, VerifyingKey};
+use signing::{signature::ecdsa::secp256k1, VerifyingKey};
 use tonic::{Request, Response, Status};
+use tower::{Service, ServiceExt};
 use tracing::trace;
-use types::ethereum::Address;
-
-/// Keccak256 digest.
-type H256 = [u8; 32];
+use types::{ethereum::Address, BoxError, Bytes};
 
 /// Signer gRPC service.
-pub struct SignerService {
-    /// Signing keyring.
-    keyring: Keyring,
+pub struct SignerService<S> {
+    /// Reference to the signer service.
+    signing_service: S,
 }
 
-impl SignerService {
+impl<S> SignerService<S>
+where
+    S: Service<signing::Request, Response = signing::Response, Error = BoxError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    S::Future: Send,
+{
     /// Create a new RPC service with the given keyring.
-    pub fn new(keyring: Keyring) -> Self {
-        Self { keyring }
+    pub fn new(signing_service: S) -> Self {
+        Self { signing_service }
     }
 
     /// Parse the given string as an Ethereum address and look up the
     /// corresponding key in the keyring.
-    fn sign_digest(&self, addr: &str, digest: &[u8]) -> Result<Signature, Error> {
-        let addr = addr.parse::<Address>().map_err(Error::from)?;
-
-        let signing_key = self
-            .keyring
-            .find_by_eth_address(&addr)
-            .map_err(Error::from)?;
-
-        let verifying_key = match signing_key.verifying_key() {
-            VerifyingKey::EcdsaSecp256k1(vk) => vk,
-            #[allow(unreachable_patterns)]
-            _ => {
-                return Err(Error::SigningKeyNotFound {
-                    addr: addr.to_string(),
-                })
-            }
+    async fn sign_digest(&self, address: Address, digest: Bytes) -> Result<Signature, Error> {
+        let request = signing::Request::SignPrehash {
+            key_handle: address.into(),
+            prehash: digest.clone(),
         };
 
-        let digest = H256::try_from(digest).map_err(|_| Error::DigestMalformed)?;
-        let raw_signature =
-            secp256k1::Signature::try_from(signing_key.sign_prehash(&digest)?.as_ref())?;
+        let (signature, verifying_key) = match self.call_service(request).await {
+            Ok(signing::Response::SignPrehash {
+                signature,
+                verifying_key: VerifyingKey::EcdsaSecp256k1(verifying_key),
+            }) => (signature, verifying_key),
+            other => todo!("handle bad response: {:?}", other),
+        };
 
+        // TODO(tarcieri): less janky signature recovery API
+        let digest = <[u8; 32]>::try_from(digest.as_ref()).map_err(|_| Error::DigestMalformed)?;
         let signature = secp256k1::RecoverableSignature::from_digest_bytes_trial_recovery(
             &verifying_key,
             &digest.into(),
-            &raw_signature,
+            &secp256k1::Signature::try_from(signature.as_ref())?,
         )?;
 
         let r = signature.r().to_bytes().to_vec();
@@ -58,10 +58,30 @@ impl SignerService {
 
         Ok(Signature { r, s, v: v.into() })
     }
+
+    /// Make a request to the signing service.
+    async fn call_service(&self, req: signing::Request) -> signing::Result<signing::Response> {
+        self.signing_service
+            .clone()
+            .ready()
+            .await
+            .expect("signing service not ready") // TODO(tarcieri): handle this?
+            .call(req)
+            .await
+            .map_err(Into::into)
+    }
 }
 
 #[tonic::async_trait]
-impl Signer for SignerService {
+impl<S> Signer for SignerService<S>
+where
+    S: Service<signing::Request, Response = signing::Response, Error = BoxError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    S::Future: Send,
+{
     async fn sign_digest(
         &self,
         request: Request<SignDigestRequest>,
@@ -69,8 +89,11 @@ impl Signer for SignerService {
         trace!("sign_digest[{:?}]: {:?}", request.remote_addr(), request);
 
         let request = request.into_inner();
+        let address = request.address.parse::<Address>().map_err(Error::from)?;
+
         Ok(self
-            .sign_digest(&request.address, &request.digest)
+            .sign_digest(address, request.digest.into())
+            .await
             .map(Response::new)
             .map_err(Error::from)?)
     }
@@ -82,8 +105,11 @@ impl Signer for SignerService {
         trace!("sign_eip155[{:?}]: {:?}", request.remote_addr(), request);
 
         let request = request.into_inner();
+        let address = request.address.parse::<Address>().map_err(Error::from)?;
+
         let mut signature = self
-            .sign_digest(&request.address, &request.digest)
+            .sign_digest(address, request.digest.into())
+            .await
             .map_err(Error::from)?;
 
         // Apply EIP-155

--- a/iqkms-signing/Cargo.toml
+++ b/iqkms-signing/Cargo.toml
@@ -22,6 +22,8 @@ features = ["ecdsa", "getrandom", "sha2", "std"]
 path = "../iq-crypto"
 
 [dependencies]
+tower = "0.4"
+
 # optional dependencies
 types = { package = "iqkms-types", version = "0.0.1", optional = true, path = "../iqkms-types" }
 

--- a/iqkms-signing/src/error.rs
+++ b/iqkms-signing/src/error.rs
@@ -1,12 +1,29 @@
 //! Error types.
 
+use std::fmt;
+use types::BoxError;
+
+/// Result type with the `iqkms-signing` crate's [`Error`] type.
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// Error type.
 // TODO(tarcieri): convert this into an enum?
 #[derive(Clone, Copy, Debug)]
 pub struct Error;
 
-/// Result type with the `iqkms-signing` crate's [`Error`] type.
-pub type Result<T> = std::result::Result<T, Error>;
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Error")
+    }
+}
+
+impl From<BoxError> for Error {
+    fn from(_: BoxError) -> Error {
+        Error
+    }
+}
 
 impl From<crypto::signature::Error> for Error {
     fn from(_: crypto::signature::Error) -> Error {

--- a/iqkms-signing/src/error.rs
+++ b/iqkms-signing/src/error.rs
@@ -8,6 +8,12 @@ pub struct Error;
 /// Result type with the `iqkms-signing` crate's [`Error`] type.
 pub type Result<T> = std::result::Result<T, Error>;
 
+impl From<crypto::signature::Error> for Error {
+    fn from(_: crypto::signature::Error) -> Error {
+        Error
+    }
+}
+
 #[cfg(feature = "ethereum")]
 impl From<types::Error> for Error {
     fn from(_: types::Error) -> Error {

--- a/iqkms-signing/src/keyring.rs
+++ b/iqkms-signing/src/keyring.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, SigningKey, VerifyingKey};
+use crate::{signing_key::SigningKey, verifying_key::VerifyingKey, Error, Result};
 use std::{
     collections::BTreeMap as Map,
     fmt::{self, Debug},
@@ -9,7 +9,7 @@ use types::ethereum;
 
 /// Keys for producing digital signatures.
 #[derive(Default)]
-pub struct Keyring {
+pub(crate) struct Keyring {
     /// Signing keys.
     keys: Map<VerifyingKey, SigningKey>,
 
@@ -19,12 +19,8 @@ pub struct Keyring {
 }
 
 impl Keyring {
-    /// Create a new key ring.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Add a key to the ring.
+    #[allow(dead_code)] // TODO(tarcieri): use me!
     pub fn add(&mut self, signing_key: SigningKey) -> Result<()> {
         let verifying_key = signing_key.verifying_key();
 

--- a/iqkms-signing/src/keyring.rs
+++ b/iqkms-signing/src/keyring.rs
@@ -1,5 +1,4 @@
 use crate::{Error, Result, SigningKey, VerifyingKey};
-use crypto::signature::ecdsa;
 use std::{
     collections::BTreeMap as Map,
     fmt::{self, Debug},
@@ -45,21 +44,11 @@ impl Keyring {
     /// Find a key by its Ethereum address.
     #[cfg(feature = "ethereum")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ethereum")))]
-    pub fn find_by_eth_address(
-        &self,
-        addr: &ethereum::Address,
-    ) -> Result<&ecdsa::secp256k1::SigningKey> {
-        let signing_key = self
-            .eth_index
-            .get(addr)
+    pub fn find_by_eth_address(&self, eth_addr: &ethereum::Address) -> Result<&SigningKey> {
+        self.eth_index
+            .get(eth_addr)
             .and_then(|vk| self.keys.get(vk))
-            .ok_or(Error)?;
-
-        match signing_key {
-            SigningKey::EcdsaSecp256k1(key) => Ok(key),
-            #[allow(unreachable_patterns)]
-            _ => Err(Error),
-        }
+            .ok_or(Error)
     }
 }
 

--- a/iqkms-signing/src/lib.rs
+++ b/iqkms-signing/src/lib.rs
@@ -25,12 +25,14 @@
 
 mod error;
 mod keyring;
+mod service;
 mod signing_key;
 mod verifying_key;
 
 pub use crate::{
     error::{Error, Result},
     keyring::Keyring,
+    service::{KeyHandle, SigningService},
     signing_key::SigningKey,
     verifying_key::VerifyingKey,
 };

--- a/iqkms-signing/src/lib.rs
+++ b/iqkms-signing/src/lib.rs
@@ -31,9 +31,7 @@ mod verifying_key;
 
 pub use crate::{
     error::{Error, Result},
-    keyring::Keyring,
-    service::{KeyHandle, SigningService},
-    signing_key::SigningKey,
+    service::{KeyHandle, Request, Response, SigningService},
     verifying_key::VerifyingKey,
 };
 pub use crypto::signature;

--- a/iqkms-signing/src/service.rs
+++ b/iqkms-signing/src/service.rs
@@ -1,0 +1,96 @@
+use crate::{Error, Keyring, Result};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::Service;
+use types::Bytes;
+
+#[cfg(feature = "ethereum")]
+use types::ethereum;
+
+/// Tower service which controls access to the signing [`Keyring`].
+#[derive(Debug, Default)]
+pub struct SigningService {
+    /// Signing keyring.
+    keyring: Keyring,
+}
+
+impl SigningService {
+    /// Create new [`SigningService`] with an empty keyring.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sign the given prehash using the key with the given handle.
+    fn sign_prehash(&self, req: SignPrehashRequest) -> Result<Response> {
+        let signing_key = match req.key_handle {
+            #[cfg(feature = "ethereum")]
+            KeyHandle::Ethereum(eth_addr) => self.keyring.find_by_eth_address(&eth_addr)?,
+            #[allow(unreachable_patterns)]
+            _ => return Err(Error),
+        };
+
+        let signature = signing_key.sign_prehash(&req.prehash)?;
+        Ok(Response::SignPrehash(SignPrehashResponse { signature }))
+    }
+}
+
+impl Service<Request> for SigningService {
+    type Response = Response;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Response>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _ctx: &mut Context<'_>) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let result = match request {
+            Request::SignPrehash(req) => self.sign_prehash(req),
+        };
+
+        Box::pin(async { result })
+    }
+}
+
+/// Requests to the signing service.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Request {
+    SignPrehash(SignPrehashRequest),
+}
+
+/// Responses from the signing service.
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub enum Response {
+    SignPrehash(SignPrehashResponse),
+}
+
+/// Request to sign the given prehash.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignPrehashRequest {
+    /// Handle to the given signing key.
+    key_handle: KeyHandle,
+
+    /// Message prehash to be signed.
+    prehash: Bytes,
+}
+
+/// Response from a [`SignPrehashRequest`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignPrehashResponse {
+    /// Resulting algorithm-specific signature, serialized as bytes.
+    signature: Bytes,
+}
+
+/// Handle to a key in the signing keyring.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum KeyHandle {
+    /// Key identified by its Ethereum address, e.g.
+    /// `0x27b1fdb04752bbc536007a920d24acb045561c26`
+    #[cfg(feature = "ethereum")]
+    Ethereum(ethereum::Address),
+}

--- a/iqkms-signing/src/service.rs
+++ b/iqkms-signing/src/service.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Keyring, Result};
+use crate::{keyring::Keyring, Error, Result, VerifyingKey};
 use std::{
     future::Future,
     pin::Pin,
@@ -10,7 +10,7 @@ use types::Bytes;
 #[cfg(feature = "ethereum")]
 use types::ethereum;
 
-/// Tower service which controls access to the signing [`Keyring`].
+/// Tower service which controls access to the signing keyring.
 #[derive(Debug, Default)]
 pub struct SigningService {
     /// Signing keyring.
@@ -24,16 +24,21 @@ impl SigningService {
     }
 
     /// Sign the given prehash using the key with the given handle.
-    fn sign_prehash(&self, req: SignPrehashRequest) -> Result<Response> {
-        let signing_key = match req.key_handle {
+    fn sign_prehash(&self, key_handle: KeyHandle, prehash: &[u8]) -> Result<Response> {
+        let signing_key = match key_handle {
             #[cfg(feature = "ethereum")]
             KeyHandle::Ethereum(eth_addr) => self.keyring.find_by_eth_address(&eth_addr)?,
             #[allow(unreachable_patterns)]
             _ => return Err(Error),
         };
 
-        let signature = signing_key.sign_prehash(&req.prehash)?;
-        Ok(Response::SignPrehash(SignPrehashResponse { signature }))
+        let verifying_key = signing_key.verifying_key();
+        let signature = signing_key.sign_prehash(prehash)?;
+
+        Ok(Response::SignPrehash {
+            signature,
+            verifying_key,
+        })
     }
 }
 
@@ -48,7 +53,10 @@ impl Service<Request> for SigningService {
 
     fn call(&mut self, request: Request) -> Self::Future {
         let result = match request {
-            Request::SignPrehash(req) => self.sign_prehash(req),
+            Request::SignPrehash {
+                key_handle,
+                prehash,
+            } => self.sign_prehash(key_handle, &prehash),
         };
 
         Box::pin(async { result })
@@ -59,38 +67,42 @@ impl Service<Request> for SigningService {
 #[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Request {
-    SignPrehash(SignPrehashRequest),
+    /// Sign the provided prehash.
+    SignPrehash {
+        /// Handle to the given signing key.
+        key_handle: KeyHandle,
+
+        /// Message prehash to be signed.
+        prehash: Bytes,
+    },
 }
 
 /// Responses from the signing service.
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub enum Response {
-    SignPrehash(SignPrehashResponse),
-}
+    SignPrehash {
+        /// Verifying key which corresponds to this signer.
+        verifying_key: VerifyingKey,
 
-/// Request to sign the given prehash.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SignPrehashRequest {
-    /// Handle to the given signing key.
-    key_handle: KeyHandle,
-
-    /// Message prehash to be signed.
-    prehash: Bytes,
-}
-
-/// Response from a [`SignPrehashRequest`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SignPrehashResponse {
-    /// Resulting algorithm-specific signature, serialized as bytes.
-    signature: Bytes,
+        /// Resulting algorithm-specific signature, serialized as bytes.
+        signature: Bytes,
+    },
 }
 
 /// Handle to a key in the signing keyring.
+// TODO(tarcieri): OCap-like access control for key handles?
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum KeyHandle {
     /// Key identified by its Ethereum address, e.g.
     /// `0x27b1fdb04752bbc536007a920d24acb045561c26`
     #[cfg(feature = "ethereum")]
     Ethereum(ethereum::Address),
+}
+
+#[cfg(feature = "ethereum")]
+impl From<ethereum::Address> for KeyHandle {
+    fn from(eth_addr: ethereum::Address) -> KeyHandle {
+        KeyHandle::Ethereum(eth_addr)
+    }
 }

--- a/iqkms-signing/src/signing_key.rs
+++ b/iqkms-signing/src/signing_key.rs
@@ -35,11 +35,11 @@ impl SigningKey {
     /// Sign the given message with this key.
     // TODO(tarcieri): support for customizing hash function used
     pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
-        self.sign_digest(&Sha256::digest(msg))
+        self.sign_prehash(&Sha256::digest(msg))
     }
 
     /// Sign the given prehashed message digest with this key.
-    pub fn sign_digest(&self, msg_digest: &[u8]) -> Result<Vec<u8>> {
+    pub fn sign_prehash(&self, msg_digest: &[u8]) -> Result<Vec<u8>> {
         match self {
             #[cfg(feature = "secp256k1")]
             Self::EcdsaSecp256k1(sk) => {

--- a/iqkms-signing/src/signing_key.rs
+++ b/iqkms-signing/src/signing_key.rs
@@ -5,6 +5,7 @@ use crypto::{
     signature::{ecdsa, hazmat::PrehashSigner},
 };
 use std::fmt::{self, Debug};
+use types::Bytes;
 
 /// Signing key.
 pub enum SigningKey {
@@ -19,6 +20,7 @@ impl SigningKey {
     // TODO(tarcieri): unified `generate` method with algorithm parameter
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+    #[allow(dead_code)] // TODO(tarcieri): use me!
     pub fn generate_secp256k1() -> Self {
         let mut bytes = [0u8; 32];
 
@@ -34,17 +36,18 @@ impl SigningKey {
 
     /// Sign the given message with this key.
     // TODO(tarcieri): support for customizing hash function used
-    pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
+    #[allow(dead_code)] // TODO(tarcieri): use me!
+    pub fn sign(&self, msg: &[u8]) -> Result<Bytes> {
         self.sign_prehash(&Sha256::digest(msg))
     }
 
     /// Sign the given prehashed message digest with this key.
-    pub fn sign_prehash(&self, msg_digest: &[u8]) -> Result<Vec<u8>> {
+    pub fn sign_prehash(&self, msg_digest: &[u8]) -> Result<Bytes> {
         match self {
             #[cfg(feature = "secp256k1")]
             Self::EcdsaSecp256k1(sk) => {
                 PrehashSigner::<ecdsa::secp256k1::Signature>::sign_prehash(sk, msg_digest)
-                    .map(|sig| sig.to_vec())
+                    .map(|sig| sig.to_vec().into())
                     .map_err(|_| Error)
             }
         }

--- a/iqkms-types/Cargo.toml
+++ b/iqkms-types/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 readme = "README.md"
 
 [dependencies]
+bytes = "1.2"
 crypto = { package = "iq-crypto", version = "0.0.1", optional = true, path = "../iq-crypto" }
 
 # 3rd party dependencies

--- a/iqkms-types/src/error.rs
+++ b/iqkms-types/src/error.rs
@@ -1,5 +1,9 @@
 //! Error types.
 
+/// Box containing a thread-safe + `'static` error suitable for use as a as
+/// `std::error::Error::source`.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 /// Error type.
 // TODO(tarcieri): convert this into an enum?
 #[derive(Clone, Debug)]

--- a/iqkms-types/src/lib.rs
+++ b/iqkms-types/src/lib.rs
@@ -23,7 +23,8 @@ pub mod ethereum;
 
 mod error;
 
-pub use crate::error::{Error, Result};
+pub use crate::error::{BoxError, Error, Result};
+pub use bytes::{self, Bytes};
 
 #[cfg(feature = "crypto")]
 #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
@@ -32,7 +33,3 @@ pub use crypto;
 #[cfg(feature = "hex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hex")))]
 pub use hex;
-
-/// Immutable bytestring representation.
-// TODO(tarcieri): use `bytes::Bytes` instead?
-pub type Bytes = Vec<u8>;

--- a/iqkms-types/src/lib.rs
+++ b/iqkms-types/src/lib.rs
@@ -32,3 +32,7 @@ pub use crypto;
 #[cfg(feature = "hex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hex")))]
 pub use hex;
+
+/// Immutable bytestring representation.
+// TODO(tarcieri): use `bytes::Bytes` instead?
+pub type Bytes = Vec<u8>;

--- a/iqkmsd/Cargo.toml
+++ b/iqkmsd/Cargo.toml
@@ -21,5 +21,7 @@ ethereum = { package = "iqkms-ethereum", version = "0.0.1", path = "../iqkms-eth
 proto = { package = "iqkms-proto", version = "0.0.1", path = "../iqkms-proto" }
 signing = { package = "iqkms-signing", version = "0.0.1", path = "../iqkms-signing" }
 
+# 3rd party dependencies
 tokio = { version = "1", features = ["full"] }
 tonic = "0.8"
+tower = "0.4"

--- a/iqkmsd/src/main.rs
+++ b/iqkmsd/src/main.rs
@@ -1,14 +1,19 @@
-use tonic::transport::Server;
+use signing::SigningService;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:27100".parse().unwrap();
-    let keyring = signing::Keyring::new();
-    let eth_service = ethereum::SignerService::new(keyring);
 
+    let signing_service = tower::ServiceBuilder::new()
+        .buffer(10) // TODO(tarcieri): tune buffer size
+        .service(SigningService::new());
+
+    let eth_service = ethereum::SignerService::new(signing_service);
+
+    // TODO(tarcieri): use tracing for logging
     println!("Listening on {}", addr);
 
-    Server::builder()
+    tonic::transport::Server::builder()
         .add_service(ethereum::SignerServer::new(eth_service))
         .serve(addr)
         .await?;


### PR DESCRIPTION
Adds a `tower::Service` which owns `iqkms_signing::Keyring`.

The goal is to force all signing requests through this service, making it the central location for controlling access to signing keys.

Such access control is not yet implemented in this PR.