### PR TITLE
Bump all crates to Rust 2024 edition; MSRV 1.85

### DIFF
--- a/.github/workflows/ethereum.yml
+++ b/.github/workflows/ethereum.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ethers-iqkms.yml
+++ b/.github/workflows/ethers-iqkms.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/iq-crypto.yml
+++ b/.github/workflows/iq-crypto.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/iqkms.yml
+++ b/.github/workflows/iqkms.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/iqkmsd.yml
+++ b/.github/workflows/iqkmsd.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70 # MSRV
+          - 1.85 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           components: clippy
       - run: sudo apt-get install protobuf-compiler
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/ethers-iqkms/Cargo.toml
+++ b/ethers-iqkms/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/ethers-iqkms"
 categories = ["cryptography::cryptocurrencies"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/ethers-iqkms/README.md
+++ b/ethers-iqkms/README.md
@@ -19,7 +19,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -58,7 +58,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/ethers-iqkms.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/ethers-iqkms.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/ethers-iqkms/src/lib.rs
+++ b/ethers-iqkms/src/lib.rs
@@ -7,7 +7,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     clippy::panic,
     // clippy::panic_in_result_fn,
     clippy::unwrap_used,
@@ -20,19 +20,18 @@
 pub use ethers_core::types;
 
 use ethers_core::types::{
-    transaction::{eip2718::TypedTransaction, eip712::Eip712},
     Signature,
+    transaction::{eip712::Eip712, eip2718::TypedTransaction},
 };
 use ethers_signers::Signer;
 use iqkms::{
-    proto,
+    Error, StdError, proto,
     tokio::sync::Mutex,
     tonic,
     types::{
-        crypto::digest::{sha3::Keccak256, Digest},
+        crypto::digest::{Digest, sha3::Keccak256},
         ethereum::{Address, ChainId, H160, H256, U256},
     },
-    Error, StdError,
 };
 use std::{fmt, sync::Arc};
 use tracing::instrument;

--- a/iq-crypto/Cargo.toml
+++ b/iq-crypto/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/iq-crypto"
 categories = ["cryptography"]
 keywords = ["crypto", "digest", "ecdsa"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/iq-crypto/README.md
+++ b/iq-crypto/README.md
@@ -20,7 +20,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -54,7 +54,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/iq-crypto.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/iq-crypto.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0+MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/iq-crypto/src/lib.rs
+++ b/iq-crypto/src/lib.rs
@@ -15,7 +15,7 @@
     clippy::cast_sign_loss,
     clippy::checked_conversions,
     clippy::implicit_saturating_sub,
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/iq-crypto/src/signature.rs
+++ b/iq-crypto/src/signature.rs
@@ -8,6 +8,6 @@ mod algorithm;
 
 pub use self::algorithm::Algorithm;
 pub use ::signature::{
-    hazmat, DigestSigner, DigestVerifier, Error, Keypair, PrehashSignature, RandomizedDigestSigner,
-    RandomizedSigner, Result, Signature, Signer, SignerMut, Verifier,
+    DigestSigner, DigestVerifier, Error, Keypair, PrehashSignature, RandomizedDigestSigner,
+    RandomizedSigner, Result, Signature, Signer, SignerMut, Verifier, hazmat,
 };

--- a/iq-crypto/src/signature/ecdsa/secp256k1.rs
+++ b/iq-crypto/src/signature/ecdsa/secp256k1.rs
@@ -1,8 +1,8 @@
 //! ECDSA/secp256k1 support.
 
 pub use k256::ecdsa::{
-    recoverable::{Id as RecoveryId, Signature as RecoverableSignature},
     Signature, VerifyingKey,
+    recoverable::{Id as RecoveryId, Signature as RecoverableSignature},
 };
 
 use crate::{Error, Result};

--- a/iqkms-ethereum/Cargo.toml
+++ b/iqkms-ethereum/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/iqkms-ethereum"
 categories = ["cryptography::cryptocurrencies"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/iqkms-ethereum/README.md
+++ b/iqkms-ethereum/README.md
@@ -18,7 +18,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -57,7 +57,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/ethereum.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/ethereum.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/iqkms-ethereum/src/error.rs
+++ b/iqkms-ethereum/src/error.rs
@@ -35,7 +35,7 @@ impl Error {
     fn code(&self) -> tonic::Code {
         match self {
             Error::AddressMalformed { .. } => tonic::Code::InvalidArgument,
-            Error::DigestMalformed { .. } => tonic::Code::InvalidArgument,
+            Error::DigestMalformed => tonic::Code::InvalidArgument,
             Error::SigningKeyNotFound { .. } => tonic::Code::NotFound,
             Error::SigningFailed { .. } => tonic::Code::Internal,
         }

--- a/iqkms-proto/Cargo.toml
+++ b/iqkms-proto/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/iqkms-proto"
 categories = ["cryptography", "data-structures", "encoding"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/iqkms-proto/README.md
+++ b/iqkms-proto/README.md
@@ -18,7 +18,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -57,7 +57,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/proto.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/proto.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/iqkms-signing/Cargo.toml
+++ b/iqkms-signing/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/iqkms-signing"
 categories = ["cryptography"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies.crypto]

--- a/iqkms-signing/README.md
+++ b/iqkms-signing/README.md
@@ -23,7 +23,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -62,7 +62,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/signing.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/signing.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/iqkms-signing/src/keyring.rs
+++ b/iqkms-signing/src/keyring.rs
@@ -1,4 +1,4 @@
-use crate::{signing_key::SigningKey, verifying_key::VerifyingKey, Error, Result};
+use crate::{Error, Result, signing_key::SigningKey, verifying_key::VerifyingKey};
 use std::{
     collections::BTreeMap as Map,
     fmt::{self, Debug},

--- a/iqkms-signing/src/lib.rs
+++ b/iqkms-signing/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,

--- a/iqkms-signing/src/service.rs
+++ b/iqkms-signing/src/service.rs
@@ -1,4 +1,4 @@
-use crate::{keyring::Keyring, Error, Result, VerifyingKey};
+use crate::{Error, Result, VerifyingKey, keyring::Keyring};
 use std::{
     future::Future,
     pin::Pin,

--- a/iqkms-signing/src/signing_key.rs
+++ b/iqkms-signing/src/signing_key.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, VerifyingKey};
 use crypto::{
-    digest::{sha2::Sha256, Digest},
+    digest::{Digest, sha2::Sha256},
     rand::{OsRng, RngCore},
     signature::{ecdsa, hazmat::PrehashSigner},
 };

--- a/iqkms-types/Cargo.toml
+++ b/iqkms-types/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/iqkms-types"
 categories = ["cryptography"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/iqkms-types/README.md
+++ b/iqkms-types/README.md
@@ -19,7 +19,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -58,7 +58,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/types.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/types.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/iqkms-types/src/ethereum.rs
+++ b/iqkms-types/src/ethereum.rs
@@ -2,13 +2,13 @@
 
 // Re-export select types from the `ethereum-types` crate.
 pub use ethereum_types::{
-    BigEndianHash, FromDecStrErr, FromStrRadixErr, FromStrRadixErrKind, H128, H160, H256, H264,
-    H32, H512, H520, H64, U128, U256, U512, U64,
+    BigEndianHash, FromDecStrErr, FromStrRadixErr, FromStrRadixErrKind, H32, H64, H128, H160, H256,
+    H264, H512, H520, U64, U128, U256, U512,
 };
 
 use crate::{Error, Result};
 use crypto::{
-    digest::{sha3::Keccak256, Digest, Update},
+    digest::{Digest, Update, sha3::Keccak256},
     elliptic_curve::{
         sec1::{self, ToEncodedPoint},
         secp256k1::EncodedPoint,
@@ -105,6 +105,7 @@ impl FromStr for Address {
 /// Encode address as EIP-55 mixed-case checksum encoding.
 ///
 /// <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md>
+#[allow(clippy::to_string_trait_impl)] // TODO(tarcieri): implement in a `Display`-friendly way?
 impl ToString for Address {
     fn to_string(&self) -> String {
         let addr_hex = hex::lower::encode_string(self.as_ref());
@@ -139,7 +140,7 @@ impl TryFrom<&EncodedPoint> for Address {
                 let digest = Keccak256::new().chain(x).chain(y).finalize();
 
                 // Take the last 20 bytes of the digest as the address
-                #[allow(clippy::integer_arithmetic)]
+                #[allow(clippy::arithmetic_side_effects)]
                 digest[(Address::LENGTH - 20)..].try_into()
             }
             _ => Err(Error),

--- a/iqkms-types/src/lib.rs
+++ b/iqkms-types/src/lib.rs
@@ -7,7 +7,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/iqkms/Cargo.toml
+++ b/iqkms/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/ethers-iqkms"
 categories = ["cryptography"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/iqkms/README.md
+++ b/iqkms/README.md
@@ -24,7 +24,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -63,7 +63,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/iqkms.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/iqkms.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/iqkms/src/ethereum.rs
+++ b/iqkms/src/ethereum.rs
@@ -1,13 +1,13 @@
 //! iqkms Ethereum support
 
 pub use types::{
-    crypto::digest::{sha3::Keccak256, Digest},
+    crypto::digest::{Digest, sha3::Keccak256},
     ethereum::{Address, ChainId, H256},
 };
 
 use crate::{Error, StdError};
 use proto::ethereum::{SignDigestRequest, SignEip155Request, Signature};
-use tonic::{transport, Request};
+use tonic::{Request, transport};
 
 /// Tonic-generated inner gRPC client.
 type SignerClientInner = proto::ethereum::signer_client::SignerClient<transport::Channel>;

--- a/iqkms/src/lib.rs
+++ b/iqkms/src/lib.rs
@@ -7,7 +7,7 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
-    clippy::integer_arithmetic,
+    clippy::arithmetic_side_effects,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/iqkms/tests/ethereum.rs
+++ b/iqkms/tests/ethereum.rs
@@ -6,8 +6,8 @@
 #![cfg(feature = "ethereum")]
 
 use iqkms::{
-    ethereum::{Address, SignerClient, H256},
     StdError,
+    ethereum::{Address, H256, SignerClient},
 };
 
 #[ignore]

--- a/iqkmsd/Cargo.toml
+++ b/iqkmsd/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://github.com/iqlusioninc/iqkms/"
 repository = "https://github.com/iqlusioninc/iqkms/tree/main/iqkmsd"
 categories = ["cryptography"]
 keywords = ["iqkms", "kms"]
-rust-version = "1.64"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 readme = "README.md"
 
 [dependencies]

--- a/iqkmsd/README.md
+++ b/iqkmsd/README.md
@@ -24,7 +24,7 @@ Please check back later.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.64** at a minimum.
+This crate requires **Rust 1.85** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -63,7 +63,7 @@ licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/iqkms/actions/workflows/iqkmsd.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/iqkms/actions/workflows/iqkmsd.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.64+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 


### PR DESCRIPTION
Also applies rustfmt with the new rules, and updates some clippy lints