### PR TITLE
cometbft-p2p: borrowing `AsyncSecretConnection::peer_public_key`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "cometbft-p2p"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "aead",
  "base16ct 0.2.0",

--- a/cometbft-p2p/Cargo.toml
+++ b/cometbft-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cometbft-p2p"
 description = "Pure Rust implementation of CometBFT's encrypted P2P protocol"
-version = "0.1.0"
+version = "0.2.0-pre"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/iqkms"

--- a/cometbft-p2p/src/async_secret_connection.rs
+++ b/cometbft-p2p/src/async_secret_connection.rs
@@ -109,11 +109,8 @@ impl<Io> AsyncSecretConnection<Io> {
     }
 
     /// Returns the remote peer's [`PublicKey`].
-    ///
-    /// # Panics
-    /// - if the peer's public key is not initialized (library-internal bug)
-    pub fn peer_public_key(&self) -> PublicKey {
-        self.peer_public_key
+    pub fn peer_public_key(&self) -> &PublicKey {
+        &self.peer_public_key
     }
 
     /// Split this [`AsyncSecretConnection`] into an [`AsyncSecretReader`] and [`AsyncSecretWriter`]


### PR DESCRIPTION
All of the other public key methods e.g. `local_public_key` including the ones on the synchronous `SecretConnection` borrow the public key.

This is more consistent, but also an unfortunate oversight and breaking change. Fortunately, this library doesn't have any users yet.

Also bumps the version to `0.2.0-pre` to denote the breaking change.