### PR TITLE
cometbft-p2p: remove obsolete panic warning

### DIFF
--- a/cometbft-p2p/src/async_secret_connection.rs
+++ b/cometbft-p2p/src/async_secret_connection.rs
@@ -109,11 +109,8 @@ impl<Io> AsyncSecretConnection<Io> {
     }
 
     /// Returns the remote peer's [`PublicKey`].
-    ///
-    /// # Panics
-    /// - if the peer's public key is not initialized (library-internal bug)
-    pub fn peer_public_key(&self) -> PublicKey {
-        self.peer_public_key
+    pub fn peer_public_key(&self) -> &PublicKey {
+        &self.peer_public_key
     }
 
     /// Split this [`AsyncSecretConnection`] into an [`AsyncSecretReader`] and [`AsyncSecretWriter`]


### PR DESCRIPTION
The panic condition no longer exists