### PR TITLE
cometbft-p2p: use `doc_cfg`

### DIFF
--- a/cometbft-p2p/src/lib.rs
+++ b/cometbft-p2p/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::all,


### PR DESCRIPTION
`doc_auto_cfg` has been replaced by `doc_cfg`